### PR TITLE
Return certified companies when query string is appended to /companies

### DIFF
--- a/src/routes/companies/companies.controller.js
+++ b/src/routes/companies/companies.controller.js
@@ -2,7 +2,15 @@ const db = require('../../db');
 
 // exports.index = get all the companies
 exports.index = (req, res) => {
-  db.collection('companies')
+  // Create a reference to the companies collection
+  const companiesRef = db.collection('companies');
+
+  // Create a query against the collection.
+  let dbQuery = companiesRef;
+  if (req.query.filter === 'certified') {
+    dbQuery = companiesRef.where('score', '>=', 6);
+  }
+  dbQuery
     .get()
     .then(snapshot =>
       snapshot.docs.map(doc => {


### PR DESCRIPTION
Rather than creating a new endpoint to return only the certified companies, I used query string parameters to update the database query.

So when `/companies?filter=certified` is hit, only the certified companies will be returned. 

![image](https://user-images.githubusercontent.com/26798587/54445893-1ea07780-471c-11e9-8903-2d444815551e.png)

Right now `certified` means >= 6/10 but this will have to be updated. We could use a percentage for the score so that if the number of checklist items changes, it will still work.

Everything else should work as normal. Please check /companies to see that all the companies (certified or not) are being returned. 

NOTE: You won't be able to test this until I update the thunk on the front end!!! Coming soon!

