### PR TITLE
order companies by score

### DIFF
--- a/src/routes/companies/companies.controller.js
+++ b/src/routes/companies/companies.controller.js
@@ -8,9 +8,10 @@ exports.index = (req, res) => {
   // Create a query against the collection.
   let dbQuery = companiesRef;
   if (req.query.filter === 'certified') {
-    dbQuery = companiesRef.where('score', '>=', 6);
+    dbQuery = companiesRef.where('score', '>=', 6).orderBy('score', 'desc');
   }
   dbQuery
+    .orderBy('name', 'asc')
     .get()
     .then(snapshot =>
       snapshot.docs.map(doc => {


### PR DESCRIPTION
I added the "Order By" method to sort certified companies by score and sorting all companies by name.
This way, we can have our matches sorted by score but the companies list sorted by name. This required me to create a composite index, but it was very easy to set up (i just clicked the link in the terminal) 👍 

This should be checked with the frontend pull request